### PR TITLE
Adventure 5 update

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -22,11 +22,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Set up JDK 17
+      - name: Set up JDK 25
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 25
 
       - name: Build Jar
         run: ./gradlew jar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Set up JDK 17
+      - name: Set up JDK 25
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 25
 
       - name: Build Jar
         run: ./gradlew jar

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ repositories {
 dependencies {
     compileOnly("com.velocitypowered:velocity-api:4.1.0-SNAPSHOT")
     annotationProcessor("com.velocitypowered:velocity-api:4.1.0-SNAPSHOT")
-    implementation("fr.pickaria:messager:1.0-SNAPSHOT")
+    implementation("fr.pickaria:messager:1.2-SNAPSHOT")
     implementation("org.apache.commons:commons-text:1.14.0")
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,10 +10,11 @@ version = '1.8.0-SNAPSHOT'
 
 repositories {
     mavenCentral()
-    maven {
-        name "pickariaRepositorySnapshots"
-        url "https://maven.pickaria.fr/snapshots"
-    }
+    mavenLocal()
+    //maven {
+    //    name "pickariaRepositorySnapshots"
+    //    url "https://maven.pickaria.fr/snapshots"
+    //}
     maven {
         name = "papermc-repo"
         url = "https://repo.papermc.io/repository/maven-public/"
@@ -25,13 +26,13 @@ repositories {
 }
 
 dependencies {
-    compileOnly("com.velocitypowered:velocity-api:3.4.0-SNAPSHOT")
-    annotationProcessor("com.velocitypowered:velocity-api:3.4.0-SNAPSHOT")
+    compileOnly("com.velocitypowered:velocity-api:4.1.0-SNAPSHOT")
+    annotationProcessor("com.velocitypowered:velocity-api:4.1.0-SNAPSHOT")
     implementation("fr.pickaria:messager:1.0-SNAPSHOT")
     implementation("org.apache.commons:commons-text:1.14.0")
 }
 
-def targetJavaVersion = 17
+def targetJavaVersion = 25
 java {
     toolchain.languageVersion = JavaLanguageVersion.of(targetJavaVersion)
 }
@@ -52,7 +53,7 @@ tasks {
         // Configure the Velocity version for our task.
         // This is the only required configuration besides applying the plugin.
         // Your plugin's jar (or shadowJar if present) will be used automatically.
-        velocityVersion("3.4.0-SNAPSHOT")
+        velocityVersion("4.1.0-SNAPSHOT")
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/fr/pickaria/pterodactylpoweraction/ConnectionListener.java
+++ b/src/main/java/fr/pickaria/pterodactylpoweraction/ConnectionListener.java
@@ -43,7 +43,7 @@ public class ConnectionListener {
         this.proxy = proxy;
         this.logger = logger;
         this.shutdownManager = shutdownManager;
-        this.messager = new Messager();
+        this.messager = Messager.builder().build();
     }
 
     @Subscribe()

--- a/src/main/java/fr/pickaria/pterodactylpoweraction/PterodactylPowerAction.java
+++ b/src/main/java/fr/pickaria/pterodactylpoweraction/PterodactylPowerAction.java
@@ -14,10 +14,11 @@ import fr.pickaria.pterodactylpoweraction.configuration.ConfigurationLoader;
 import fr.pickaria.pterodactylpoweraction.configuration.ShutdownBehaviour;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.translation.GlobalTranslator;
-import net.kyori.adventure.translation.TranslationRegistry;
+import net.kyori.adventure.translation.TranslationStore;
 import org.slf4j.Logger;
 
 import java.nio.file.Path;
+import java.text.MessageFormat;
 import java.time.Duration;
 import java.util.Locale;
 import java.util.NoSuchElementException;
@@ -75,12 +76,12 @@ public class PterodactylPowerAction {
     }
 
     private void initializeTranslator(ResourceBundle... bundles) {
-        TranslationRegistry registry = TranslationRegistry.create(Key.key("pickaria:power_action"));
+        TranslationStore.StringBased<MessageFormat> store = TranslationStore.messageFormat(Key.key("pickaria:power_action"));
         for (ResourceBundle bundle : bundles) {
-            registry.registerAll(bundle.getLocale(), bundle, true);
+            store.registerAll(bundle.getLocale(), bundle, true);
         }
-        registry.defaultLocale(Locale.ENGLISH);
-        GlobalTranslator.translator().addSource(registry);
+        store.defaultLocale(Locale.ENGLISH);
+        GlobalTranslator.translator().addSource(store);
     }
 
     private void initializeCommand() {

--- a/src/main/java/fr/pickaria/pterodactylpoweraction/PterodactylPowerAction.java
+++ b/src/main/java/fr/pickaria/pterodactylpoweraction/PterodactylPowerAction.java
@@ -15,7 +15,6 @@ import fr.pickaria.pterodactylpoweraction.configuration.ShutdownBehaviour;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.translation.GlobalTranslator;
 import net.kyori.adventure.translation.TranslationRegistry;
-import net.kyori.adventure.util.UTF8ResourceBundleControl;
 import org.slf4j.Logger;
 
 import java.nio.file.Path;
@@ -49,9 +48,9 @@ public class PterodactylPowerAction {
         this.initializeCommand();
 
         initializeTranslator(
-                ResourceBundle.getBundle("PterodactylPowerAction.Bundle", Locale.FRENCH, UTF8ResourceBundleControl.get()),
-                ResourceBundle.getBundle("PterodactylPowerAction.Bundle", Locale.ENGLISH, UTF8ResourceBundleControl.get()),
-                ResourceBundle.getBundle("PterodactylPowerAction.Bundle", Locale.GERMAN, UTF8ResourceBundleControl.get())
+                ResourceBundle.getBundle("PterodactylPowerAction.Bundle", Locale.FRENCH),
+                ResourceBundle.getBundle("PterodactylPowerAction.Bundle", Locale.ENGLISH),
+                ResourceBundle.getBundle("PterodactylPowerAction.Bundle", Locale.GERMAN)
         );
 
         try {

--- a/src/main/java/fr/pickaria/pterodactylpoweraction/commands/PterodactylPowerActionCommand.java
+++ b/src/main/java/fr/pickaria/pterodactylpoweraction/commands/PterodactylPowerActionCommand.java
@@ -36,7 +36,7 @@ public class PterodactylPowerActionCommand {
         this.logger = logger;
         this.configurationLoader = configurationLoader;
         this.shutdownManager = shutdownManager;
-        this.messager = new Messager();
+        this.messager = Messager.builder().build();
     }
 
     public BrigadierCommand createBrigadierCommand() {


### PR DESCRIPTION
### Updated dependencies:
 - Velocity 3.4.0-SNAPSHOT -> 4.1.0-SNAPSHOT
 - Messager 1.0-SNAPSHOT -> 1.2-SNAPSHOT (to be removed #17)
 - Gradle 9.2.0 -> 9.6.1
 - Java (GitHub workflows) 17 -> 25

### Removed classes unsupported by Adventure 5:
 - **TranslationRegistry**, replaced with **TranslationStore**
 - **UTF8ResourceBundleControl**, not needed anymore

Resolves #16 